### PR TITLE
Clarify skill matrix variables

### DIFF
--- a/data.py
+++ b/data.py
@@ -5,7 +5,8 @@ This module constructs the synthetic call-arrival and worker-skill data used
 throughout the project.  NumPy is employed to draw samples from exponential
 distributions so that each run produces a slightly different workload.  The
 output consists of a matrix of incoming calls (:data:`call_input_list`) as well
-as several worker skill matrices (:data:`A`, :data:`B`, :data:`C`).  These
+as several worker skill matrices (:data:`SKILL_MATRIX_BASE`,
+:data:`SKILL_MATRIX_PRIMARY_ONLY`, :data:`SKILL_MATRIX_ALTERNATIVE`).  These
 variables are imported by :mod:`call` and :mod:`worker` when building their
 respective objects.  Constants defined here are treated as the default inputs
 for the simulation engine.
@@ -14,56 +15,6 @@ for the simulation engine.
 import numpy as np
 import numpy.random as rnd  # used to generate random numbers
 import helpers
-
-# Example matrices of worker skills
-
-# k1 = [8, 6, 2, 1]
-# k2 = [8, 2, 6, 2]
-# k3 = [8, 2, 1, 1]
-# k4 = [8, 2, 1, 1]
-# k5 = [8, 1, 2, 2]
-# l1 = [2, 8, 2, 6]
-# l2 = [6, 8, 1, 2]
-# l3 = [1, 8, 1, 1]
-# I1 = [6, 1, 8, 2]
-# I2 = [1, 2, 8, 6]
-# I3 = [2, 2, 8, 1]
-# I4 = [1, 2, 8, 1]
-# m1 = [2, 2, 6, 8]
-# m2 = [2, 6, 2, 8]
-# m3 = [1, 2, 2, 8]
-
-# k11 = [8, 2, 2, 1]
-# k21 = [8, 2, 1, 2]
-# k31 = [8, 2, 1, 1]
-# k41 = [8, 2, 1, 1]
-# k51 = [8, 1, 2, 2]
-# l11 = [2, 8, 2, 2]
-# l21 = [1, 8, 1, 2]
-# l31 = [1, 8, 1, 1]
-# I11 = [1, 1, 8, 2]
-# I21 = [1, 2, 8, 1]
-# I31 = [2, 2, 8, 1]
-# I41 = [1, 2, 8, 1]
-# m11 = [2, 2, 1, 8]
-# m21 = [2, 1, 2, 8]
-# m31 = [1, 2, 2, 8]
-
-# k12 = [8, 2, 6, 1]
-# k22 = [8, 3, 1, 6]
-# k32 = [8, 6, 1, 1]
-# k42 = [8, 2, 1, 1]
-# k52 = [8, 1, 2, 2]
-# l12 = [2, 8, 2, 6]
-# l22 = [5, 8, 1, 2]
-# l32 = [1, 8, 6, 1]
-# I12 = [1, 6, 8, 2]
-# I22 = [6, 2, 8, 1]
-# I32 = [2, 2, 8, 6]
-# I42 = [1, 2, 8, 1]
-# m12 = [2, 2, 6, 8]
-# m22 = [5, 1, 2, 8]
-# m32 = [1, 6, 2, 8]
 
 
 team_size = np.array([5, 3, 4, 3])  # Number of workers per department
@@ -74,9 +25,68 @@ max_calls = [200, 180, 270, 110]  # Maximum calls per department
 tSLA = np.array([18.0, 12.0, 10.0, 25.0])  # SLA target per department
 incoming_calls = np.array([180, 160, 250, 95])  # Incoming calls per department
 
-A = np.hstack([np.array([1,2,1,3,1,0,1,0,1,0,2,4,2,1,2,0,3,1,3,4,3,0,3,0,4,3,4,2,4,0]).reshape(15,2),np.zeros([15,2])])
-B = np.hstack([np.array([1,0,1,0,1,0,1,0,1,0,2,0,2,0,2,0,3,0,3,0,3,0,3,0,4,0,4,0,4,0]).reshape(15,2),np.zeros([15,2])])
-C =  np.hstack([np.array([1,2,1,3,1,0,1,0,1,0,2,4,2,1,2,0,3,1,3,4,3,0,3,0,4,3,4,2,4,0]).reshape(15,2),np.zeros([15,2])])
+SKILL_MATRIX_BASE = np.hstack([
+    np.array([
+        1, 2,
+        1, 3,
+        1, 0,
+        1, 0,
+        1, 0,
+        2, 4,
+        2, 1,
+        2, 0,
+        3, 1,
+        3, 4,
+        3, 0,
+        3, 0,
+        4, 3,
+        4, 2,
+        4, 0,
+    ]).reshape(15, 2),
+    np.zeros([15, 2]),
+])
+
+SKILL_MATRIX_PRIMARY_ONLY = np.hstack([
+    np.array([
+        1, 0,
+        1, 0,
+        1, 0,
+        1, 0,
+        1, 0,
+        2, 0,
+        2, 0,
+        2, 0,
+        3, 0,
+        3, 0,
+        3, 0,
+        3, 0,
+        4, 0,
+        4, 0,
+        4, 0,
+    ]).reshape(15, 2),
+    np.zeros([15, 2]),
+])
+
+SKILL_MATRIX_ALTERNATIVE = np.hstack([
+    np.array([
+        1, 2,
+        1, 3,
+        1, 0,
+        1, 0,
+        1, 0,
+        2, 4,
+        2, 1,
+        2, 0,
+        3, 1,
+        3, 4,
+        3, 0,
+        3, 0,
+        4, 3,
+        4, 2,
+        4, 0,
+    ]).reshape(15, 2),
+    np.zeros([15, 2]),
+])
 
 total_workers = team_size.sum()  # Total number of workers
 work_minutes_department = total_minutes * team_size  # Work minutes per department

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def _load_agents_from_env(env_file: str):
     from worker import build_agent_list
     import data
 
-    return build_agent_list(data.A, team_size, quality)
+    return build_agent_list(data.SKILL_MATRIX_BASE, team_size, quality)
 
 
 def _write_results(runs: int, agents=None, filename: str = "results.txt") -> None:

--- a/tests/test_env_cli.py
+++ b/tests/test_env_cli.py
@@ -13,9 +13,9 @@ def test_build_agent_list_respects_env(monkeypatch):
     dummy = types.SimpleNamespace(
         tSLA=[0, 0, 0, 0],
         team_size=[],
-        A=None,
-        B=None,
-        C=None,
+        SKILL_MATRIX_BASE=None,
+        SKILL_MATRIX_PRIMARY_ONLY=None,
+        SKILL_MATRIX_ALTERNATIVE=None,
         call_input_list=[],
     )
     monkeypatch.setitem(sys.modules, 'data', dummy)
@@ -37,9 +37,9 @@ def test_build_agent_list_respects_quality(monkeypatch):
     dummy = types.SimpleNamespace(
         tSLA=[0, 0, 0, 0],
         team_size=[],
-        A=None,
-        B=None,
-        C=None,
+        SKILL_MATRIX_BASE=None,
+        SKILL_MATRIX_PRIMARY_ONLY=None,
+        SKILL_MATRIX_ALTERNATIVE=None,
         call_input_list=[],
     )
     monkeypatch.setitem(sys.modules, 'data', dummy)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12,9 +12,9 @@ class DummyMatrix:
 
 sys.modules['data'] = types.SimpleNamespace(
     team_size=[],
-    A=DummyMatrix(),
-    B=DummyMatrix(),
-    C=DummyMatrix(),
+    SKILL_MATRIX_BASE=DummyMatrix(),
+    SKILL_MATRIX_PRIMARY_ONLY=DummyMatrix(),
+    SKILL_MATRIX_ALTERNATIVE=DummyMatrix(),
     tSLA=[],
     call_input_list=[],
 )

--- a/worker.py
+++ b/worker.py
@@ -2,7 +2,12 @@
 
 import itertools  # Helper for constructing the worker matrices
 
-from data import A, B, C, tSLA
+from data import (
+    SKILL_MATRIX_BASE,
+    SKILL_MATRIX_PRIMARY_ONLY,
+    SKILL_MATRIX_ALTERNATIVE,
+    tSLA,
+)
 from department import Department
 import config
 
@@ -150,9 +155,15 @@ def build_agent_list(skill_matrix, team_size, quality_levels=None, helper_skill=
 # Agent matrices used during the simulation.  When tests monkeypatch ``data``
 # these may fail to build, so fall back to empty lists in that case.
 try:
-    agents = build_agent_list(A, config.TEAM_SIZE, config.QUALITY)
-    agents2 = build_agent_list(B, config.TEAM_SIZE, config.QUALITY)
-    agents3 = build_agent_list(C, config.TEAM_SIZE, config.QUALITY)
+    agents = build_agent_list(
+        SKILL_MATRIX_BASE, config.TEAM_SIZE, config.QUALITY
+    )
+    agents2 = build_agent_list(
+        SKILL_MATRIX_PRIMARY_ONLY, config.TEAM_SIZE, config.QUALITY
+    )
+    agents3 = build_agent_list(
+        SKILL_MATRIX_ALTERNATIVE, config.TEAM_SIZE, config.QUALITY
+    )
 except Exception:
     agents = []
     agents2 = []


### PR DESCRIPTION
## Summary
- clean up `data.py` comments and rename A/B/C matrices
- update worker creation to use new skill matrix names
- adjust CLI helper to reference new name
- adapt tests to patched constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa751627c833393b3996ee0f47226